### PR TITLE
Fix for component name dups

### DIFF
--- a/snippets/React (ES7).cson
+++ b/snippets/React (ES7).cson
@@ -45,7 +45,7 @@
       }
     """
 
-  'React ES7 Component':
+  'React ES7 Component Props':
     'prefix': 'rcp'
     'body': """
       import React, { Component } from 'react';
@@ -92,7 +92,7 @@
       }
     """
 
-  'React ES7 Component with Constructor':
+  'React ES7 Component with Constructor Props':
     'prefix': 'rccp'
     'body': """
       import React, { Component } from 'react';


### PR DESCRIPTION
I was getting name dup errors when loading this plugin so I added 'Props' to name of components that take props.