### PR TITLE
Fix duplicated keys

### DIFF
--- a/snippets/React (ES7).cson
+++ b/snippets/React (ES7).cson
@@ -45,7 +45,7 @@
       }
     """
 
-  'React ES7 Component':
+  'React ES7 Component with Props':
     'prefix': 'rcp'
     'body': """
       import React, { Component } from 'react';
@@ -92,7 +92,7 @@
       }
     """
 
-  'React ES7 Component with Constructor':
+  'React ES7 Component with Constructor and Props':
     'prefix': 'rccp'
     'body': """
       import React, { Component } from 'react';


### PR DESCRIPTION
React ES7 Component -> React ES7 Component vs. React ES7 Component with PropTypes

React ES7 Component with Constructor -> React ES7 Component with Constructor vs. React ES7 Component with Constructor with PropTypes